### PR TITLE
Exclude tmp and dist folder

### DIFF
--- a/blueprints/denali-typescript/files/tsconfig.json
+++ b/blueprints/denali-typescript/files/tsconfig.json
@@ -13,5 +13,9 @@
       "skipLibCheck": true,
       "sourceRoot": "."
   },
-  "exclude": [ "blueprints/*/files/**" ]
+  "exclude": [ 
+    "blueprints/*/files/**",
+    "tmp",
+    "dist"
+  ]
 }


### PR DESCRIPTION
This fixes a problem where vscode `typescript.referencesCodeLens.enabled: true` would also include references to `tmp` and `dist` folders.

I'm not sure what other side effects this has. But I'm assuming they are good lol 😛 